### PR TITLE
deploy: deploy.sh 실행 사용자명 변경

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -4,4 +4,4 @@ hooks:
   ApplicationStart:
     - location: deploy.sh
       timeout: 300
-      runas: ubuntu
+      runas: root


### PR DESCRIPTION
deploy.sh를 실행할 사용자를 명시적으로 지정함

차후 IAM 권한을 배포 전용 사용자에게 할당하고 해당 사용자 이름으로 변경해야함